### PR TITLE
change type of FrameRate properties from int to double

### DIFF
--- a/src/Gfycat.Net/API/Models/Gfy.cs
+++ b/src/Gfycat.Net/API/Models/Gfy.cs
@@ -42,7 +42,7 @@ namespace Gfycat.API.Models
         [JsonProperty("avgColor")]
         internal string AverageColor { get; set; }
         [JsonProperty("frameRate")]
-        internal int FrameRate { get; set; }
+        internal double FrameRate { get; set; }
         [JsonProperty("numFrames")]
         internal int NumberOfFrames { get; set; }
         [JsonProperty("mp4Size")]

--- a/src/Gfycat.Net/Gfy.cs
+++ b/src/Gfycat.Net/Gfy.cs
@@ -214,7 +214,7 @@ namespace Gfycat
         /// <summary>
         /// Gets the framerate for this gfy
         /// </summary>
-        public int FrameRate { get; private set; }
+        public double FrameRate { get; private set; }
         /// <summary>
         /// Gets the number of frames for this gfy
         /// </summary>


### PR DESCRIPTION
Ran into an issue where the frame rate of some gfys is not an integer:

![image](https://user-images.githubusercontent.com/1325428/35605457-ab588b7e-05fd-11e8-8f40-036550bddfec.png)

Seems simple enough, so thought I'd try a PR.